### PR TITLE
Add a mock-recording job

### DIFF
--- a/service/jobs_api.go
+++ b/service/jobs_api.go
@@ -44,8 +44,8 @@ func (s *Service) handleCreateJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	job, err := s.jobService.CreateRecordingJobDocker(cfg, func(job Job) error {
-		job, err := s.GetJob(job.ID)
+	job, err := s.jobService.CreateRecordingJobDocker(cfg, func(jobID string) error {
+		job, err := s.GetJob(jobID)
 		if err != nil {
 			return err
 		}

--- a/service/random/id.go
+++ b/service/random/id.go
@@ -14,7 +14,7 @@ const charset = "ybndrfg8ejkmcpqxot1uwisza345h769"
 
 var encoding = base32.NewEncoding(charset)
 
-// NewID is a globally unique identifier.  It is a [A-Z0-9] string 26
+// NewID is a globally unique identifier.  It is a [a-z0-9] string 26
 // characters long.  It is a UUID version 4 Guid that is zbased32 encoded
 // with the padding stripped off.
 func NewID() string {


### PR DESCRIPTION
#### Summary
- use: `MOCK_RECORDING_JOB=true go run -v ./cmd/offloader`
- It uses a non-threadsafe map to keep the cbs. Should be good enough for testing purposes, but let me know. 

#### Ticket Link
- none