### PR TITLE
[MM-49189] Cleanup resources on successful job

### DIFF
--- a/service/audit.go
+++ b/service/audit.go
@@ -60,7 +60,7 @@ func reqAuditFields(req *http.Request) []mlog.Field {
 		mlog.String("remoteAddr", req.RemoteAddr),
 		mlog.String("method", req.Method),
 		mlog.String("url", req.URL.String()),
-		mlog.Any("header", req.Header),
+		mlog.Any("header", hdr),
 		mlog.String("host", req.Host),
 	}
 	return fields

--- a/service/audit.go
+++ b/service/audit.go
@@ -54,7 +54,8 @@ func (s *Service) httpAudit(handler string, data *httpData, w http.ResponseWrite
 }
 
 func reqAuditFields(req *http.Request) []mlog.Field {
-	delete(req.Header, "Authorization")
+	hdr := req.Header.Clone()
+	delete(hdr, "Authorization")
 	fields := []mlog.Field{
 		mlog.String("remoteAddr", req.RemoteAddr),
 		mlog.String("method", req.Method),

--- a/service/jobs_api.go
+++ b/service/jobs_api.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -44,19 +45,32 @@ func (s *Service) handleCreateJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	job, err := s.jobService.CreateRecordingJobDocker(cfg, func(job Job) error {
+	job, err := s.jobService.CreateRecordingJobDocker(cfg, func(job Job, exitCode int) error {
+		s.log.Info("job stopped", mlog.String("jobID", job.ID), mlog.Int("exitCode", exitCode))
+
 		job, err := s.GetJob(job.ID)
 		if err != nil {
 			return err
 		}
-		// checking if job was already stopped
-		if job.StopAt > 0 {
-			return nil
+
+		if job.StopAt == 0 {
+			job.StopAt = time.Now().UnixMilli()
+			if err := s.SaveJob(job); err != nil {
+				return err
+			}
 		}
-		job.StopAt = time.Now().UnixMilli()
-		if err := s.SaveJob(job); err != nil {
-			return err
+
+		if exitCode == dockerGracefulExitCode {
+			s.log.Debug("job completed successfully, removing",
+				mlog.String("jobID", job.ID), mlog.Int("exitCode", exitCode))
+			if err := s.jobService.RemoveRecordingJobDocker(job.ID); err != nil {
+				return fmt.Errorf("failed to remove recording job: %w", err)
+			}
+			if err := s.DeleteJob(job.ID); err != nil {
+				return err
+			}
 		}
+
 		return nil
 	})
 	if err != nil {
@@ -184,4 +198,47 @@ func (s *Service) handleJobGetLogs(w http.ResponseWriter, r *http.Request) {
 	if _, err := w.Write(logs); err != nil {
 		s.log.Error("failed to write response", mlog.Err(err))
 	}
+}
+
+func (s *Service) handleDeleteJob(w http.ResponseWriter, r *http.Request) {
+	data := newHTTPData()
+	defer s.httpAudit("handleRemoveJob", data, w, r)
+
+	clientID, code, err := s.authHandler(w, r)
+	if err != nil {
+		data.err = err.Error()
+		data.code = code
+		return
+	}
+	data.clientID = clientID
+
+	jobID := mux.Vars(r)["id"]
+	if jobID == "" {
+		data.err = "missing job ID"
+		data.code = http.StatusBadRequest
+		return
+	}
+
+	job, err := s.GetJob(jobID)
+	if err != nil {
+		data.err = "failed to get job " + err.Error()
+		data.code = http.StatusNotFound
+		return
+	}
+
+	// TODO: consider adding a force removal option to cover edge cases.
+	if job.StopAt == 0 {
+		data.err = "job is running"
+		data.code = http.StatusBadRequest
+		return
+	}
+
+	err = s.jobService.RemoveRecordingJobDocker(jobID)
+	if err != nil {
+		data.err = "failed to remove recording job: " + err.Error()
+		data.code = http.StatusInternalServerError
+		return
+	}
+
+	data.code = http.StatusOK
 }

--- a/service/service.go
+++ b/service/service.go
@@ -83,6 +83,7 @@ func New(cfg Config) (*Service, error) {
 	router.HandleFunc("/jobs/{id:[a-z0-9]+}/stop", s.handleStopJob).Methods("POST")
 	router.HandleFunc("/jobs/{id:[a-z0-9]+}/logs", s.handleJobGetLogs).Methods("GET")
 	router.HandleFunc("/jobs/{id:[a-z0-9]+}", s.handleGetJob).Methods("GET")
+	router.HandleFunc("/jobs/{id:[a-z0-9]+}", s.handleDeleteJob).Methods("DELETE")
 
 	router.Handle("/debug/pprof/heap", pprof.Handler("heap"))
 	router.Handle("/debug/pprof/goroutine", pprof.Handler("goroutine"))

--- a/service/store/bitcask.go
+++ b/service/store/bitcask.go
@@ -31,6 +31,8 @@ func newBitcaskStore(path string) (*bitcaskStore, error) {
 }
 
 func (s *bitcaskStore) Set(key, value string) error {
+	s.mut.Lock()
+	defer s.mut.Unlock()
 	if key == "" {
 		return ErrEmptyKey
 	}
@@ -71,6 +73,8 @@ func (s *bitcaskStore) Put(key, value string) error {
 }
 
 func (s *bitcaskStore) Get(key string) (string, error) {
+	s.mut.RLock()
+	defer s.mut.RUnlock()
 	if key == "" {
 		return "", ErrEmptyKey
 	}
@@ -84,6 +88,8 @@ func (s *bitcaskStore) Get(key string) (string, error) {
 }
 
 func (s *bitcaskStore) Delete(key string) error {
+	s.mut.Lock()
+	defer s.mut.Unlock()
 	if key == "" {
 		return ErrEmptyKey
 	}
@@ -101,6 +107,8 @@ func (s *bitcaskStore) Delete(key string) error {
 }
 
 func (s *bitcaskStore) Close() error {
+	s.mut.Lock()
+	defer s.mut.Unlock()
 	err := s.db.Close()
 	if err != nil {
 		return fmt.Errorf("failed to close store: %w", err)


### PR DESCRIPTION
#### Summary

PR adds some logic to remove recording jobs upon successful exit. This doesn't affect the recording files since they are stored in a volume which is preserved and usually already deleted by `calls-recorder` once successfully published.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49189
