### PR TITLE
[MM-49267] Implement API endpoint to update job runner

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -84,6 +84,7 @@ func New(cfg Config) (*Service, error) {
 	router.HandleFunc("/jobs/{id:[a-z0-9]+}/logs", s.handleJobGetLogs).Methods("GET")
 	router.HandleFunc("/jobs/{id:[a-z0-9]+}", s.handleGetJob).Methods("GET")
 	router.HandleFunc("/jobs/{id:[a-z0-9]+}", s.handleDeleteJob).Methods("DELETE")
+	router.HandleFunc("/jobs/update-runner", s.handleUpdateJobRunner).Methods("POST")
 
 	router.Handle("/debug/pprof/heap", pprof.Handler("heap"))
 	router.Handle("/debug/pprof/goroutine", pprof.Handler("goroutine"))


### PR DESCRIPTION
#### Summary

PR decouples the existing logic to update the runner (docker image) so that it can be used independently from the API. This allows the plugin side to do this potentially time expensive operation asynchronously on activation rather than waiting for the first recording job to start. 

#### Related PR

https://github.com/mattermost/mattermost-plugin-calls/pull/286

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49267
