### PR TITLE
[MM-49635] Add minimum supported version for recorder

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	git.mills.io/prologic/bitcask v1.0.2
 	github.com/BurntSushi/toml v1.2.1
+	github.com/Masterminds/semver v1.5.0
 	github.com/docker/docker v20.10.9+incompatible
 	github.com/gorilla/mux v1.8.0
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak=
 github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=

--- a/service/job_test.go
+++ b/service/job_test.go
@@ -33,7 +33,7 @@ func TestJobConfigIsValid(t *testing.T) {
 				Type:   JobTypeRecording,
 				Runner: "testrepo/calls-recorder:v0.1.0",
 			},
-			expectedError: "invalid Runner value: parsing failed",
+			expectedError: "invalid Runner value: failed to validate runner",
 		},
 		{
 			name: "invalid runner",
@@ -41,7 +41,7 @@ func TestJobConfigIsValid(t *testing.T) {
 				Type:   JobTypeRecording,
 				Runner: "testrepo/calls-recorder@sha256:abcde",
 			},
-			expectedError: "invalid Runner value: parsing failed",
+			expectedError: "invalid Runner value: failed to validate runner",
 		},
 		{
 			name: "invalid job type",
@@ -55,7 +55,7 @@ func TestJobConfigIsValid(t *testing.T) {
 			name: "invalid max duration",
 			cfg: JobConfig{
 				Type:   JobTypeRecording,
-				Runner: "mattermost/calls-recorder:v0.1.0",
+				Runner: "mattermost/calls-recorder:v0.2.2",
 				InputData: map[string]any{
 					"site_url":   "http://localhost:8065",
 					"call_id":    "8w8jorhr7j83uqr6y1st894hqe",
@@ -67,7 +67,7 @@ func TestJobConfigIsValid(t *testing.T) {
 			expectedError: "invalid MaxDurationSec value: should not be negative",
 		},
 		{
-			name: "valid",
+			name: "invalid version",
 			cfg: JobConfig{
 				Type:   JobTypeRecording,
 				Runner: "mattermost/calls-recorder:v0.1.0",
@@ -77,14 +77,14 @@ func TestJobConfigIsValid(t *testing.T) {
 					"thread_id":  "udzdsg7dwidbzcidx5khrf8nee",
 					"auth_token": "qj75unbsef83ik9p7ueypb6iyw",
 				},
-				MaxDurationSec: 60,
 			},
+			expectedError: "invalid Runner value: actual version (0.1.0) is lower than minimum supported version (0.2.2)",
 		},
 		{
 			name: "valid",
 			cfg: JobConfig{
 				Type:   JobTypeRecording,
-				Runner: "mattermost/calls-recorder@sha256:5192dd075638655265c8e5e0a34631ab32f970a198c3a096f4b4cc115c853931",
+				Runner: "mattermost/calls-recorder:v0.2.2",
 				InputData: map[string]any{
 					"site_url":   "http://localhost:8065",
 					"call_id":    "8w8jorhr7j83uqr6y1st894hqe",

--- a/service/jobs_api.go
+++ b/service/jobs_api.go
@@ -268,8 +268,8 @@ func (s *Service) handleUpdateJobRunner(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	if !JobRunnerIsValid(runner) {
-		data.err = "invalid job runner"
+	if err := JobRunnerIsValid(runner); err != nil {
+		data.err = "invalid job runner: " + err.Error()
 		data.code = http.StatusBadRequest
 		return
 	}

--- a/service/utils.go
+++ b/service/utils.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2022-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package service
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver"
+)
+
+func checkMinVersion(minVersion, actualVersion string) error {
+	minV, err := semver.NewVersion(minVersion)
+	if err != nil {
+		return fmt.Errorf("failed to parse minVersion: %w", err)
+	}
+
+	currV, err := semver.NewVersion(actualVersion)
+	if err != nil {
+		return fmt.Errorf("failed to parse actualVersion: %w", err)
+	}
+
+	if cmp := currV.Compare(minV); cmp < 0 {
+		return fmt.Errorf("actual version (%s) is lower than minimum supported version (%s)", actualVersion, minVersion)
+	}
+
+	return nil
+}

--- a/service/utils_test.go
+++ b/service/utils_test.go
@@ -1,0 +1,87 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckMinVersion(t *testing.T) {
+	tcs := []struct {
+		name          string
+		minVersion    string
+		actualVersion string
+		err           string
+	}{
+		{
+			name:          "empty minVersion",
+			minVersion:    "",
+			actualVersion: "",
+			err:           "failed to parse minVersion: Invalid Semantic Version",
+		},
+		{
+			name:          "empty actualVersion",
+			minVersion:    "0.1.0",
+			actualVersion: "",
+			err:           "failed to parse actualVersion: Invalid Semantic Version",
+		},
+		{
+			name:          "invalid minVersion",
+			minVersion:    "not.a.version",
+			actualVersion: "not.a.version",
+			err:           "failed to parse minVersion: Invalid Semantic Version",
+		},
+		{
+			name:          "invalid actualVersion",
+			minVersion:    "0.1.0",
+			actualVersion: "not.a.version",
+			err:           "failed to parse actualVersion: Invalid Semantic Version",
+		},
+		{
+			name:          "not supported, minor",
+			minVersion:    "0.2.0",
+			actualVersion: "0.1.0",
+			err:           "actual version (0.1.0) is lower than minimum supported version (0.2.0)",
+		},
+		{
+			name:          "not supported, patch",
+			minVersion:    "0.2.1",
+			actualVersion: "0.2.0",
+			err:           "actual version (0.2.0) is lower than minimum supported version (0.2.1)",
+		},
+		{
+			name:          "supported, equal",
+			minVersion:    "0.2.1",
+			actualVersion: "0.2.1",
+			err:           "",
+		},
+		{
+			name:          "supported, greater",
+			minVersion:    "0.2.1",
+			actualVersion: "0.2.2",
+			err:           "",
+		},
+		{
+			name:          "supported, minVersion prefix",
+			minVersion:    "v0.2.1",
+			actualVersion: "0.2.2",
+			err:           "",
+		},
+		{
+			name:          "supported, actualVersion prefix",
+			minVersion:    "0.2.1",
+			actualVersion: "v0.2.2",
+			err:           "",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkMinVersion(tc.minVersion, tc.actualVersion)
+			if tc.err != "" {
+				assert.EqualError(t, err, tc.err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### Summary

PR adds a check on the recorder runner (docker image) so that it matches the expected minimum version.

**Note**: these changes will break passing the image by hash. To fix this we need more logic since we likely need to fetch the image and check the tags to figure out the version. Given the need to merge this asap I'd like to defer this extra work to a future release and think this through with more calm.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49635

