### PR TITLE
Allow override of docker network mode

### DIFF
--- a/service/jobs_service.go
+++ b/service/jobs_service.go
@@ -129,6 +129,11 @@ func (s *JobService) CreateRecordingJobDocker(cfg JobConfig, onStopCb stopCb) (J
 			}
 		}
 	}
+
+	if dockerNetwork := os.Getenv("DOCKER_NETWORK"); dockerNetwork != "" {
+		networkMode = container.NetworkMode(dockerNetwork)
+	}
+
 	env = append(env, jobData.ToEnv()...)
 
 	volumeID := "calls-recorder-" + random.NewID()


### PR DESCRIPTION
#### Summary

Allowing to override the docker network mode used by the job containers is necessary to make recordings work in the docker-in-docker setup we have in the e2e pipeline.