### PR TITLE
[MM-50706] Add connectivity check to API on service initialization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ CONFIG_APP_CODE         += ./cmd/offloader
 # Docker executable
 DOCKER                  := $(shell which docker)
 # Docker options to inherit for all docker run commands
-DOCKER_OPTS             += --rm -u $$(id -u):$$(id -g) --platform "linux/amd64"
+DOCKER_OPTS             += --rm --platform "linux/amd64"
 # Registry to upload images
 DOCKER_REGISTRY         ?= docker.io
 DOCKER_REGISTRY_REPO    ?= mattermost/${APP_NAME}-daily
@@ -180,6 +180,7 @@ go-test: ## to run tests
 	@$(INFO) testing...
 	$(AT)$(DOCKER) run ${DOCKER_OPTS} \
 	-v $(PWD):/app -w /app \
+	-v /var/run/docker.sock:/var/run/docker.sock \
 	-e GOCACHE="/tmp" \
 	$(DOCKER_IMAGE_GO) \
 	/bin/sh -c \

--- a/service/docker_utils.go
+++ b/service/docker_utils.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2022-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
+)
+
+func getServerVersionDocker() (types.Version, error) {
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		return types.Version{}, fmt.Errorf("failed to create docker client: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), dockerRequestTimeout)
+	defer cancel()
+
+	version, err := cli.ServerVersion(ctx)
+	if err != nil {
+		return types.Version{}, err
+	}
+
+	return version, nil
+}

--- a/service/jobs_service.go
+++ b/service/jobs_service.go
@@ -42,6 +42,20 @@ func NewJobService(cfg JobsConfig, log *mlog.Logger) (*JobService, error) {
 		return nil, fmt.Errorf("failed to validate config: %w", err)
 	}
 
+	switch cfg.APIType {
+	case JobAPITypeDocker:
+		version, err := getServerVersionDocker()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get docker server version: %w", err)
+		}
+		log.Info("connected to docker API",
+			mlog.String("version", version.Version),
+			mlog.String("api_version", version.APIVersion),
+		)
+	default:
+		return nil, fmt.Errorf("%s API is not implemeneted", cfg.APIType)
+	}
+
 	return &JobService{
 		log: log,
 		cfg: cfg,


### PR DESCRIPTION
#### Summary

PR adds a connectivity check to the underlying job API (docker in this case) during initialization. This is an effort to fail fast if something is clearly broken since otherwise the first error would come when the plugin tries to connect or worse on recording attempt.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-50706