### PR TITLE
[MM-51323] Log ImagePull output

### DIFF
--- a/service/jobs_service.go
+++ b/service/jobs_service.go
@@ -4,6 +4,7 @@
 package service
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"fmt"
@@ -86,7 +87,14 @@ func (s *JobService) UpdateJobRunnerDocker(runner string) error {
 			return fmt.Errorf("failed to pull docker image: %w", err)
 		}
 		defer out.Close()
-		_, _ = io.Copy(io.Discard, out)
+
+		scanner := bufio.NewScanner(out)
+		for scanner.Scan() {
+			s.log.Debug(scanner.Text())
+		}
+		if err := scanner.Err(); err != nil {
+			return fmt.Errorf("failed to scan output: %w", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
#### Summary

Logging `ImagePull`'s output to improve visibility on what's actually going on while updating the recorder's image.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-51323

