### PR TITLE
[MM-52382] Implement unauthorized client error

### DIFF
--- a/service/client_test.go
+++ b/service/client_test.go
@@ -126,7 +126,7 @@ func TestClientRegister(t *testing.T) {
 
 		err = c.Register("", "")
 		require.Error(t, err)
-		require.Equal(t, "request failed: authentication failed: unauthorized", err.Error())
+		require.Equal(t, ErrUnauthorized, err)
 	})
 
 	t.Run("self registering", func(t *testing.T) {
@@ -141,7 +141,7 @@ func TestClientRegister(t *testing.T) {
 		require.NoError(t, err)
 		err = c.Register("clientB", authKey)
 		require.Error(t, err)
-		require.Equal(t, "request failed: authentication failed: unauthorized", err.Error())
+		require.Equal(t, ErrUnauthorized, err)
 
 		th.srvc.cfg.API.Security.AllowSelfRegistration = true
 		err = c.Register("clientB", authKey)
@@ -195,7 +195,7 @@ func TestClientUnregister(t *testing.T) {
 
 		err = c.Unregister("clientA")
 		require.Error(t, err)
-		require.Equal(t, "request failed: authentication failed: unauthorized", err.Error())
+		require.Equal(t, ErrUnauthorized, err)
 	})
 }
 


### PR DESCRIPTION
#### Summary

Returning a proper error in case of failed client auth. This helps to properly distinguish this case and act on it from the plugin side.

#### Related PR

https://github.com/mattermost/mattermost-plugin-calls/pull/422

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-52382