### PR TITLE
MM-53083 - Fix for: Container list contains all containers

### DIFF
--- a/service/jobs_service.go
+++ b/service/jobs_service.go
@@ -125,15 +125,14 @@ func (s *JobService) CreateRecordingJobDocker(cfg JobConfig, onStopCb stopCb) (J
 		return Job{}, fmt.Errorf("failed to list containers: %w", err)
 	}
 
-	devMode := os.Getenv("DEV_MODE")
+	devMode := os.Getenv("DEV_MODE") == "true"
 
 	if len(containers) >= s.cfg.MaxConcurrentJobs {
-		if devMode == "true" {
-			s.log.Warn("max concurrent jobs reached", mlog.Int("number of active containers", len(containers)),
-				mlog.Int("cfg.MaxConcurrentJobs", s.cfg.MaxConcurrentJobs))
-		} else {
+		if !devMode {
 			return Job{}, fmt.Errorf("max concurrent jobs reached")
 		}
+		s.log.Warn("max concurrent jobs reached", mlog.Int("number of active containers", len(containers)),
+			mlog.Int("cfg.MaxConcurrentJobs", s.cfg.MaxConcurrentJobs))
 	}
 
 	if err := s.UpdateJobRunnerDocker(job.Runner); err != nil {
@@ -146,7 +145,7 @@ func (s *JobService) CreateRecordingJobDocker(cfg JobConfig, onStopCb stopCb) (J
 
 	var networkMode container.NetworkMode
 	var env []string
-	if devMode == "true" {
+	if devMode {
 		env = append(env, "DEV_MODE=true")
 		job.Runner = "calls-recorder:master"
 		if runtime.GOOS == "linux" {

--- a/service/jobs_service.go
+++ b/service/jobs_service.go
@@ -122,10 +122,6 @@ func (s *JobService) CreateRecordingJobDocker(cfg JobConfig, onStopCb stopCb) (J
 	// We fetch the list of running containers to check against it in order to
 	// ensure we don't exceed the configured MaxConcurrentJobs limit.
 	containers, err := cli.ContainerList(ctx, types.ContainerListOptions{})
-	fmt.Printf("<><> # of containers: %v\n", len(containers))
-	for i, c := range containers {
-		fmt.Printf("<><> container %d, %+#v\n", i, c)
-	}
 	if err != nil {
 		return Job{}, fmt.Errorf("failed to list containers: %w", err)
 	}

--- a/service/jobs_service.go
+++ b/service/jobs_service.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/mattermost/calls-offloader/service/random"
@@ -129,7 +130,13 @@ func (s *JobService) CreateRecordingJobDocker(cfg JobConfig, onStopCb stopCb) (J
 		return Job{}, fmt.Errorf("failed to list containers: %w", err)
 	}
 
-	if len(containers) >= s.cfg.MaxConcurrentJobs {
+	numCallRecorders := 0
+	for _, c := range containers {
+		if strings.HasPrefix(c.Image, "calls-recorder") {
+			numCallRecorders++
+		}
+	}
+	if numCallRecorders >= s.cfg.MaxConcurrentJobs {
 		return Job{}, fmt.Errorf("max concurrent jobs reached")
 	}
 

--- a/service/jobs_service.go
+++ b/service/jobs_service.go
@@ -12,7 +12,6 @@ import (
 	"net/url"
 	"os"
 	"runtime"
-	"strings"
 	"time"
 
 	"github.com/mattermost/calls-offloader/service/random"
@@ -126,13 +125,7 @@ func (s *JobService) CreateRecordingJobDocker(cfg JobConfig, onStopCb stopCb) (J
 		return Job{}, fmt.Errorf("failed to list containers: %w", err)
 	}
 
-	numCallRecorders := 0
-	for _, c := range containers {
-		if strings.HasPrefix(c.Image, "calls-recorder") {
-			numCallRecorders++
-		}
-	}
-	if numCallRecorders >= s.cfg.MaxConcurrentJobs {
+	if len(containers) >= s.cfg.MaxConcurrentJobs {
 		return Job{}, fmt.Errorf("max concurrent jobs reached")
 	}
 

--- a/service/jobs_service.go
+++ b/service/jobs_service.go
@@ -121,6 +121,10 @@ func (s *JobService) CreateRecordingJobDocker(cfg JobConfig, onStopCb stopCb) (J
 	// We fetch the list of running containers to check against it in order to
 	// ensure we don't exceed the configured MaxConcurrentJobs limit.
 	containers, err := cli.ContainerList(ctx, types.ContainerListOptions{})
+	fmt.Printf("<><> # of containers: %v\n", len(containers))
+	for i, c := range containers {
+		fmt.Printf("<><> container %d, %+#v\n", i, c)
+	}
 	if err != nil {
 		return Job{}, fmt.Errorf("failed to list containers: %w", err)
 	}


### PR DESCRIPTION
#### Summary
- Working with @DHaussermann we found we couldn't start recordings because his docker was running the 6 MM containers, so offloader thought we were past the `MaxConcurrentJobs`. Fixing that. (There doesn't seem to be an easy way to encode the image in the container list request, the `ancestor` field didn't work for me (see: https://docs.docker.com/engine/api/v1.43/#tag/Container/operation/ContainerList )).

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-53083