### PR TITLE
Update minimum support recorder version

### DIFF
--- a/service/job.go
+++ b/service/job.go
@@ -14,7 +14,7 @@ type JobType string
 
 const (
 	JobTypeRecording            JobType = "recording"
-	minSupportedRecorderVersion         = "0.3.1"
+	minSupportedRecorderVersion         = "0.3.3"
 )
 
 // We currently support two formats, semantic version tag or image hash (sha256).

--- a/service/job_test.go
+++ b/service/job_test.go
@@ -4,6 +4,7 @@
 package service
 
 import (
+	"fmt"
 	"testing"
 
 	recorder "github.com/mattermost/calls-recorder/cmd/recorder/config"
@@ -64,7 +65,7 @@ func TestJobConfigIsValid(t *testing.T) {
 			name: "invalid max duration",
 			cfg: JobConfig{
 				Type:           JobTypeRecording,
-				Runner:         "mattermost/calls-recorder:v0.3.1",
+				Runner:         "mattermost/calls-recorder:v" + minSupportedRecorderVersion,
 				InputData:      recorderCfg.ToMap(),
 				MaxDurationSec: -1,
 			},
@@ -77,13 +78,13 @@ func TestJobConfigIsValid(t *testing.T) {
 				Runner:    "mattermost/calls-recorder:v0.1.0",
 				InputData: recorderCfg.ToMap(),
 			},
-			expectedError: "invalid Runner value: actual version (0.1.0) is lower than minimum supported version (0.3.1)",
+			expectedError: fmt.Sprintf("invalid Runner value: actual version (0.1.0) is lower than minimum supported version (%s)", minSupportedRecorderVersion),
 		},
 		{
 			name: "valid",
 			cfg: JobConfig{
 				Type:           JobTypeRecording,
-				Runner:         "mattermost/calls-recorder:v0.3.1",
+				Runner:         "mattermost/calls-recorder:v" + minSupportedRecorderVersion,
 				InputData:      recorderCfg.ToMap(),
 				MaxDurationSec: 60,
 			},


### PR DESCRIPTION
#### Summary

Updating the min required version as we just released [recorder `v0.3.3`](https://hub.docker.com/layers/mattermost/calls-recorder/v0.3.3/images/sha256-e2cee54e57c8c87481089e1bf3a4d173aa7d3083c3b92a4e060e3ffeeb845047?context=explore).

Also updating the tests to ease the process going forward.