### PR TITLE
[MM-53922] Fix potential timeout error on first job creation

### DIFF
--- a/service/docker/service.go
+++ b/service/docker/service.go
@@ -149,6 +149,11 @@ func (s *JobService) CreateJob(cfg job.Config, onStopCb job.StopCb) (job.Job, er
 		return job.Job{}, fmt.Errorf("failed to update job runner: %w", err)
 	}
 
+	// We create a new context as updating the job runner could have taken more
+	// than dockerRequestTimeout.
+	ctx, cancel = context.WithTimeout(context.Background(), dockerRequestTimeout)
+	defer cancel()
+
 	var jobData recorder.RecorderConfig
 	jobData.FromMap(cfg.InputData)
 	jobData.SetDefaults()


### PR DESCRIPTION
#### Summary

There was an issue causing an erroneous timeout when starting a job that required the image to be fetched.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-53922