### PR TITLE
[MM-54232] Implement automatic client registration

### DIFF
--- a/public/job/job.go
+++ b/public/job/job.go
@@ -16,7 +16,7 @@ const (
 	TypeRecording Type = "recording"
 )
 
-const minSupportedRecorderVersion = "0.4.1"
+const MinSupportedRecorderVersion = "0.4.1"
 
 // We currently support two formats, semantic version tag or image hash (sha256).
 // TODO: Consider deprecating tag version and switch to hash only.
@@ -54,7 +54,7 @@ func (c ServiceConfig) IsValid() error {
 func RunnerIsValid(runner string) error {
 	for _, re := range recorderRunnerREs {
 		if matches := re.FindStringSubmatch(runner); len(matches) > 1 {
-			return checkMinVersion(minSupportedRecorderVersion, matches[1])
+			return checkMinVersion(MinSupportedRecorderVersion, matches[1])
 		}
 	}
 	return fmt.Errorf("failed to validate runner")

--- a/public/job/job_test.go
+++ b/public/job/job_test.go
@@ -65,7 +65,7 @@ func TestJobConfigIsValid(t *testing.T) {
 			name: "invalid max duration",
 			cfg: Config{
 				Type:           TypeRecording,
-				Runner:         "mattermost/calls-recorder:v" + minSupportedRecorderVersion,
+				Runner:         "mattermost/calls-recorder:v" + MinSupportedRecorderVersion,
 				InputData:      recorderCfg.ToMap(),
 				MaxDurationSec: -1,
 			},
@@ -78,13 +78,13 @@ func TestJobConfigIsValid(t *testing.T) {
 				Runner:    "mattermost/calls-recorder:v0.1.0",
 				InputData: recorderCfg.ToMap(),
 			},
-			expectedError: fmt.Sprintf("invalid Runner value: actual version (0.1.0) is lower than minimum supported version (%s)", minSupportedRecorderVersion),
+			expectedError: fmt.Sprintf("invalid Runner value: actual version (0.1.0) is lower than minimum supported version (%s)", MinSupportedRecorderVersion),
 		},
 		{
 			name: "valid",
 			cfg: Config{
 				Type:           TypeRecording,
-				Runner:         "mattermost/calls-recorder:v" + minSupportedRecorderVersion,
+				Runner:         "mattermost/calls-recorder:v" + MinSupportedRecorderVersion,
 				InputData:      recorderCfg.ToMap(),
 				MaxDurationSec: 60,
 			},
@@ -93,7 +93,7 @@ func TestJobConfigIsValid(t *testing.T) {
 			name: "valid daily",
 			cfg: Config{
 				Type:           TypeRecording,
-				Runner:         "mattermost/calls-recorder-daily:v" + minSupportedRecorderVersion + "-dev",
+				Runner:         "mattermost/calls-recorder-daily:v" + MinSupportedRecorderVersion + "-dev",
 				InputData:      recorderCfg.ToMap(),
 				MaxDurationSec: 60,
 			},
@@ -126,7 +126,7 @@ func TestServiceConfigIsValid(t *testing.T) {
 		{
 			name: "valid config",
 			cfg: ServiceConfig{
-				Runner: "mattermost/calls-recorder:v" + minSupportedRecorderVersion,
+				Runner: "mattermost/calls-recorder:v" + MinSupportedRecorderVersion,
 			},
 		},
 	}

--- a/service/auth/service.go
+++ b/service/auth/service.go
@@ -12,6 +12,10 @@ import (
 
 const MinKeyLen = 32
 
+var (
+	ErrAlreadyRegistered = errors.New("registration failed: already registered")
+)
+
 type Service struct {
 	sessionCache *SessionCache
 	store        store.Store
@@ -47,7 +51,7 @@ func (s *Service) Register(id, key string) error {
 	}
 
 	if _, err := s.store.Get(id); err == nil {
-		return errors.New("registration failed: already registered")
+		return ErrAlreadyRegistered
 	} else if err != nil && !errors.Is(err, store.ErrNotFound) {
 		return fmt.Errorf("registration failed: %w", err)
 	}
@@ -58,7 +62,7 @@ func (s *Service) Register(id, key string) error {
 	}
 
 	if err := s.store.Put(id, hash); errors.Is(err, store.ErrConflict) {
-		return errors.New("registration failed: already registered")
+		return ErrAlreadyRegistered
 	} else if err != nil {
 		return fmt.Errorf("registration failed: %w", err)
 	}


### PR DESCRIPTION
#### Summary

To make the service play nicely with K8S (or with any other form of load balancing of multiple instances) we added some very hacky logic in https://github.com/mattermost/mattermost-plugin-calls/pull/479 to essentially re-attempt actions due to failed authentication. Not only was this pretty horrible code to implement but also it didn't work particularly well with round-robin load balancers which would distribute each request to a different backend, causing the client to just give up after reaching the maximum failed attempts.

To alleviate these issues and simplify the flow we are adding some functionality to automatically register a client (if missing) upon authentication attempt. This has the huge benefit of removing the need to make separate HTTP requests which could all hit different endpoints. Instead, both registration and authentication are now coupled with whatever action the client is making (e.g. starting a job). This means that a call with valid credentials is guaranteed to succeed, no matter which endpoint it hits.

#### Related PR

https://github.com/mattermost/mattermost-plugin-calls/pull/501

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-54232
