### PR TITLE
Bump recorder

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/docker/docker v20.10.9+incompatible
 	github.com/gorilla/mux v1.8.0
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/mattermost/calls-recorder v0.3.4-0.20230626163552-cfc1edd174b5
+	github.com/mattermost/calls-recorder v0.4.2-0.20230830151011-a4935f7c38bf
 	github.com/mattermost/mattermost/server/public v0.0.0-20230613002302-62a3ee8adcb5
 	github.com/pborman/uuid v1.2.1
 	github.com/stretchr/testify v1.8.2

--- a/go.sum
+++ b/go.sum
@@ -532,10 +532,8 @@ github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
-github.com/mattermost/calls-recorder v0.3.2 h1:t+cIHzqFZaVehZZMx1AGso/zsT7TxzJIMUXsK1cL/cI=
-github.com/mattermost/calls-recorder v0.3.2/go.mod h1:hYhKgCc28uzcpkJjuja4tiLBfuPSCSQ6QHGkRFVygKM=
-github.com/mattermost/calls-recorder v0.3.4-0.20230626163552-cfc1edd174b5 h1:H2nFYzKR2i1wsIkrq0PzoF+JGhqN/62GSDhi/8jl8a4=
-github.com/mattermost/calls-recorder v0.3.4-0.20230626163552-cfc1edd174b5/go.mod h1:NvaEbw9B8oV2znZESocJfJ01LSKR88Ta/XCqx+U4UWI=
+github.com/mattermost/calls-recorder v0.4.2-0.20230830151011-a4935f7c38bf h1:lKbfE9CmWwHH9Fg6l/ST4PC/JMKNaZvSrvq9lnGkMW0=
+github.com/mattermost/calls-recorder v0.4.2-0.20230830151011-a4935f7c38bf/go.mod h1:NvaEbw9B8oV2znZESocJfJ01LSKR88Ta/XCqx+U4UWI=
 github.com/mattermost/logr/v2 v2.0.16 h1:jnePX4cPskC3WDFvUardh/xZfxNdsFXbEERJQ1kUEDE=
 github.com/mattermost/logr/v2 v2.0.16/go.mod h1:1dm/YhTpozsqANXxo5Pi5zYLBsal2xY0pX+JZNbzYJY=
 github.com/mattermost/mattermost/server/public v0.0.0-20230613002302-62a3ee8adcb5 h1:X8ue+QQn0VJe6qR0q2kHGFhQCn5T4rqb7XS0t6R1r3A=

--- a/public/job/job.go
+++ b/public/job/job.go
@@ -5,6 +5,7 @@ package job
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 
 	recorder "github.com/mattermost/calls-recorder/cmd/recorder/config"
@@ -16,7 +17,7 @@ const (
 	TypeRecording Type = "recording"
 )
 
-const MinSupportedRecorderVersion = "0.4.1"
+const MinSupportedRecorderVersion = "0.4.2"
 
 // We currently support two formats, semantic version tag or image hash (sha256).
 // TODO: Consider deprecating tag version and switch to hash only.
@@ -52,6 +53,10 @@ func (c ServiceConfig) IsValid() error {
 }
 
 func RunnerIsValid(runner string) error {
+	if os.Getenv("DEV_MODE") == "true" {
+		return nil
+	}
+
 	for _, re := range recorderRunnerREs {
 		if matches := re.FindStringSubmatch(runner); len(matches) > 1 {
 			return checkMinVersion(MinSupportedRecorderVersion, matches[1])

--- a/public/job/job_test.go
+++ b/public/job/job_test.go
@@ -19,6 +19,7 @@ func TestJobConfigIsValid(t *testing.T) {
 	recorderCfg.CallID = "8w8jorhr7j83uqr6y1st894hqe"
 	recorderCfg.ThreadID = "udzdsg7dwidbzcidx5khrf8nee"
 	recorderCfg.AuthToken = "qj75unbsef83ik9p7ueypb6iyw"
+	recorderCfg.RecordingID = "dtomsek53i8eukrhnb31ugyhea"
 
 	tcs := []struct {
 		name          string

--- a/service/kubernetes/utils_test.go
+++ b/service/kubernetes/utils_test.go
@@ -33,6 +33,7 @@ func TestGetEnvFromConfig(t *testing.T) {
 				cfg.AuthToken = "authToken"
 				cfg.CallID = "callID"
 				cfg.ThreadID = "threadID"
+				cfg.RecordingID = "recordingID"
 
 				return cfg
 			}(),
@@ -52,6 +53,10 @@ func TestGetEnvFromConfig(t *testing.T) {
 				{
 					Name:  "THREAD_ID",
 					Value: "threadID",
+				},
+				{
+					Name:  "RECORDING_ID",
+					Value: "recordingID",
 				},
 				{
 					Name:  "WIDTH",


### PR DESCRIPTION
#### Summary

Need to bump `calls-recorder` related dependencies and minimum version before cutting `v0.3.2`.

