### PR TITLE
[MM-54411] Use init container to set necessary node level sysctl

### DIFF
--- a/service/kubernetes/utils.go
+++ b/service/kubernetes/utils.go
@@ -37,6 +37,12 @@ func newInt64(val int64) *int64 {
 	return p
 }
 
+func newBool(val bool) *bool {
+	p := new(bool)
+	*p = val
+	return p
+}
+
 func getEnvFromConfig(cfg recorder.RecorderConfig) []corev1.EnvVar {
 	if cfg == (recorder.RecorderConfig{}) {
 		return nil


### PR DESCRIPTION
#### Summary

We are using a privileged [init container](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) to set the necessary `sysctl` setting on the kubernetes node which is required by the calls recording process (to enable using the Chromium sandbox).

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-54411
