### PR TITLE
[MM-49202] Implement retention policy of failed jobs

### DIFF
--- a/config/config.sample.toml
+++ b/config/config.sample.toml
@@ -34,6 +34,7 @@ max_concurrent_jobs = 2
 # The time to retain failed jobs before automatically deleting them and their
 # resources (i.e. volumes containing recordings). Succeeded jobs are automatically deleted upon
 # completion. A zero value means keeping failed jobs indefinitely.
+# The supported units of time are "m" (minutes), "h" (hours) and "d" (days).
 failed_jobs_retention_time = "30d"
 
 [logger]

--- a/config/config.sample.toml
+++ b/config/config.sample.toml
@@ -31,6 +31,10 @@ data_source = "/tmp/calls-offloader-db"
 api_type = "docker"
 # Maximum number of jobs allowed to be running at one time.
 max_concurrent_jobs = 2
+# The time to retain failed jobs before automatically deleting them and their
+# resources (i.e. volumes containing recordings). Succeeded jobs are automatically deleted upon
+# completion. A zero value means keeping failed jobs indefinitely.
+failed_jobs_retention_time = "30d"
 
 [logger]
 # A boolean controlling whether to log to the console.

--- a/docs/kubernetes_development.md
+++ b/docs/kubernetes_development.md
@@ -105,6 +105,8 @@ spec:
             value: "kubernetes"
           - name: JOBS_MAXCONCURRENTJOBS
             value: "1"
+          - name: JOBS_FAILEDJOBSRETENTIONTIME
+            value: "7d"
           - name: API_SECURITY_ALLOWSELFREGISTRATION # This should only be set to true if running the service inside a private network.
             value: "true"
           - name: LOGGER_CONSOLELEVEL

--- a/service/config.go
+++ b/service/config.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/mattermost/calls-offloader/logger"
 	"github.com/mattermost/calls-offloader/service/api"
@@ -69,8 +70,9 @@ const (
 )
 
 type JobsConfig struct {
-	APIType           JobAPIType `toml:"api_type"`
-	MaxConcurrentJobs int        `toml:"max_concurrent_jobs"`
+	APIType                 JobAPIType    `toml:"api_type"`
+	MaxConcurrentJobs       int           `toml:"max_concurrent_jobs"`
+	FailedJobsRetentionTime time.Duration `toml:"failed_jobs_retention_time"`
 }
 
 func (c JobsConfig) IsValid() error {
@@ -80,6 +82,14 @@ func (c JobsConfig) IsValid() error {
 
 	if c.MaxConcurrentJobs <= 0 {
 		return fmt.Errorf("invalid MaxConcurrentJobs value: should be greater than zero")
+	}
+
+	if c.FailedJobsRetentionTime < 0 {
+		return fmt.Errorf("invalid FailedJobsRetentionTime value: should be a positive duration")
+	}
+
+	if c.FailedJobsRetentionTime > 0 && c.FailedJobsRetentionTime < time.Minute {
+		return fmt.Errorf("invalid FailedJobsRetentionTime value: should be at least one minute")
 	}
 
 	return nil

--- a/service/config_test.go
+++ b/service/config_test.go
@@ -10,79 +10,60 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRetentionTimeParse(t *testing.T) {
-	newRT := func(d time.Duration) *RetentionTime {
-		rt := RetentionTime(d)
-		return &rt
-	}
-
+func TestParseRetentionTime(t *testing.T) {
 	tcs := []struct {
 		name     string
-		data     []byte
-		rt       *RetentionTime
-		expected *RetentionTime
+		input    string
+		expected time.Duration
 		err      string
 	}{
 		{
-			name:     "nil pointer",
-			data:     nil,
-			rt:       nil,
-			expected: nil,
-			err:      "invalid nil pointer",
-		},
-		{
 			name:     "invalid formatting",
-			data:     []byte("10dd"),
-			rt:       newRT(0),
-			expected: newRT(0),
+			input:    "10dd",
+			expected: 0,
 			err:      "invalid retention time format",
 		},
 		{
 			name:     "mixed units",
-			data:     []byte("10h10m"),
-			rt:       newRT(0),
-			expected: newRT(0),
+			input:    "10h10m",
+			expected: 0,
 			err:      "invalid retention time format",
 		},
 		{
 			name:     "seconds",
-			data:     []byte("45s"),
-			rt:       newRT(0),
-			expected: newRT(0),
+			input:    "45s",
+			expected: 0,
 			err:      "invalid retention time format",
 		},
 		{
 			name:     "minutes",
-			data:     []byte("45m"),
-			rt:       newRT(0),
-			expected: newRT(time.Minute * 45),
+			input:    "45m",
+			expected: time.Minute * 45,
 			err:      "",
 		},
 		{
 			name:     "hours",
-			data:     []byte("24h"),
-			rt:       newRT(0),
-			expected: newRT(time.Hour * 24),
+			input:    "24h",
+			expected: time.Hour * 24,
 			err:      "",
 		},
 		{
 			name:     "days",
-			data:     []byte("10d"),
-			rt:       newRT(0),
-			expected: newRT(time.Hour * 24 * 10),
+			input:    "10d",
+			expected: time.Hour * 24 * 10,
 			err:      "",
 		},
 	}
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			err := tc.rt.UnmarshalText(tc.data)
+			d, err := parseRetentionTime(tc.input)
 			if tc.err != "" {
 				require.EqualError(t, err, tc.err)
 			} else {
 				require.NoError(t, err)
 			}
-			require.Equal(t, tc.expected, tc.rt)
+			require.Equal(t, tc.expected, d)
 		})
 	}
 }

--- a/service/config_test.go
+++ b/service/config_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2022-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetentionTimeParse(t *testing.T) {
+	newRT := func(d time.Duration) *RetentionTime {
+		rt := RetentionTime(d)
+		return &rt
+	}
+
+	tcs := []struct {
+		name     string
+		data     []byte
+		rt       *RetentionTime
+		expected *RetentionTime
+		err      string
+	}{
+		{
+			name:     "nil pointer",
+			data:     nil,
+			rt:       nil,
+			expected: nil,
+			err:      "invalid nil pointer",
+		},
+		{
+			name:     "invalid formatting",
+			data:     []byte("10dd"),
+			rt:       newRT(0),
+			expected: newRT(0),
+			err:      "invalid retention time format",
+		},
+		{
+			name:     "mixed units",
+			data:     []byte("10h10m"),
+			rt:       newRT(0),
+			expected: newRT(0),
+			err:      "invalid retention time format",
+		},
+		{
+			name:     "seconds",
+			data:     []byte("45s"),
+			rt:       newRT(0),
+			expected: newRT(0),
+			err:      "invalid retention time format",
+		},
+		{
+			name:     "minutes",
+			data:     []byte("45m"),
+			rt:       newRT(0),
+			expected: newRT(time.Minute * 45),
+			err:      "",
+		},
+		{
+			name:     "hours",
+			data:     []byte("24h"),
+			rt:       newRT(0),
+			expected: newRT(time.Hour * 24),
+			err:      "",
+		},
+		{
+			name:     "days",
+			data:     []byte("10d"),
+			rt:       newRT(0),
+			expected: newRT(time.Hour * 24 * 10),
+			err:      "",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.rt.UnmarshalText(tc.data)
+			if tc.err != "" {
+				require.EqualError(t, err, tc.err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tc.expected, tc.rt)
+		})
+	}
+}

--- a/service/docker/service.go
+++ b/service/docker/service.go
@@ -84,7 +84,9 @@ func NewJobService(log mlog.LoggerIFace, cfg JobServiceConfig) (*JobService, err
 }
 
 func (s *JobService) retentionJob() {
-	s.log.Info("retention job is starting")
+	s.log.Info("retention job is starting",
+		mlog.Any("retention_time", s.cfg.FailedJobsRetentionTime),
+	)
 	defer func() {
 		s.log.Info("exiting retention job")
 		close(s.retentionJobDoneCh)

--- a/service/docker/service.go
+++ b/service/docker/service.go
@@ -140,7 +140,7 @@ func (s *JobService) retentionJob() {
 				}
 
 				if since := time.Since(finishedAt); since > s.cfg.FailedJobsRetentionTime {
-					s.log.Info("container has finished since more than the configured retention time, deleting",
+					s.log.Info("configured retention time has elapsed since the container finished, deleting",
 						mlog.String("id", cnt.ID),
 						mlog.Any("retention_time", s.cfg.FailedJobsRetentionTime),
 						mlog.Any("finish_at", finishedAt),

--- a/service/docker/service.go
+++ b/service/docker/service.go
@@ -78,7 +78,12 @@ func NewJobService(log mlog.LoggerIFace, cfg JobServiceConfig) (*JobService, err
 		retentionJobDoneCh: make(chan struct{}),
 	}
 
-	go s.retentionJob()
+	if s.cfg.FailedJobsRetentionTime > 0 {
+		go s.retentionJob()
+	} else {
+		s.log.Info("skipping retention job", mlog.Any("retention_time", s.cfg.FailedJobsRetentionTime))
+		close(s.retentionJobDoneCh)
+	}
 
 	return s, nil
 }

--- a/service/docker/service.go
+++ b/service/docker/service.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/mount"
 	docker "github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
@@ -33,18 +34,22 @@ const (
 )
 
 var (
-	dockerStopTimeout = 5 * time.Minute
+	dockerStopTimeout          = 5 * time.Minute
+	dockerRetentionJobInterval = time.Minute
 )
 
 type JobServiceConfig struct {
-	MaxConcurrentJobs int
+	MaxConcurrentJobs       int
+	FailedJobsRetentionTime time.Duration
 }
 
 type JobService struct {
 	cfg JobServiceConfig
 	log mlog.LoggerIFace
 
-	client *docker.Client
+	client             *docker.Client
+	stopCh             chan struct{}
+	retentionJobDoneCh chan struct{}
 }
 
 func NewJobService(log mlog.LoggerIFace, cfg JobServiceConfig) (*JobService, error) {
@@ -65,15 +70,99 @@ func NewJobService(log mlog.LoggerIFace, cfg JobServiceConfig) (*JobService, err
 		mlog.String("api_version", version.APIVersion),
 	)
 
-	return &JobService{
-		cfg:    cfg,
-		log:    log,
-		client: client,
-	}, nil
+	s := &JobService{
+		cfg:                cfg,
+		log:                log,
+		client:             client,
+		stopCh:             make(chan struct{}),
+		retentionJobDoneCh: make(chan struct{}),
+	}
+
+	go s.retentionJob()
+
+	return s, nil
+}
+
+func (s *JobService) retentionJob() {
+	s.log.Info("retention job is starting")
+	defer func() {
+		s.log.Info("exiting retention job")
+		close(s.retentionJobDoneCh)
+	}()
+
+	ticker := time.NewTicker(dockerRetentionJobInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-s.stopCh:
+			return
+		case <-ticker.C:
+			ctx, cancel := context.WithTimeout(context.Background(), dockerRequestTimeout)
+			containers, err := s.client.ContainerList(ctx, types.ContainerListOptions{
+				All: true,
+				Filters: filters.NewArgs(filters.KeyValuePair{
+					Key:   "status",
+					Value: "exited",
+				}, filters.KeyValuePair{
+					Key:   "label",
+					Value: "app=mattermost-calls-offloader",
+				}),
+			})
+			cancel()
+			if err != nil {
+				s.log.Error("failed to list containers", mlog.Err(err))
+				continue
+			}
+
+			if len(containers) == 0 {
+				// nothing to do
+				continue
+			}
+
+			for _, cnt := range containers {
+				ctx, cancel = context.WithTimeout(context.Background(), dockerRequestTimeout)
+				c, err := s.client.ContainerInspect(ctx, cnt.ID)
+				cancel()
+				if err != nil {
+					s.log.Error("failed to get container", mlog.Err(err))
+					continue
+				}
+
+				if c.State == nil {
+					s.log.Error("container state is missing", mlog.String("id", cnt.ID))
+					continue
+				}
+
+				finishedAt, err := time.Parse(time.RFC3339, c.State.FinishedAt)
+				if err != nil {
+					s.log.Error("failed to parse finish time", mlog.Err(err))
+					continue
+				}
+
+				if since := time.Since(finishedAt); since > s.cfg.FailedJobsRetentionTime {
+					s.log.Info("container has finished since more than the configured retention time, deleting",
+						mlog.String("id", cnt.ID),
+						mlog.Any("retention_time", s.cfg.FailedJobsRetentionTime),
+						mlog.Any("finish_at", finishedAt),
+						mlog.Any("since", since),
+					)
+
+					if err := s.DeleteJob(cnt.ID); err != nil {
+						s.log.Error("failed to delete job", mlog.Err(err), mlog.String("jobID", cnt.ID))
+						continue
+					}
+				}
+			}
+		}
+	}
 }
 
 func (s *JobService) Shutdown() error {
 	s.log.Info("docker job service shutting down")
+
+	close(s.stopCh)
+	<-s.retentionJobDoneCh
+
 	return s.client.Close()
 }
 
@@ -135,7 +224,12 @@ func (s *JobService) CreateJob(cfg job.Config, onStopCb job.StopCb) (job.Job, er
 
 	// We fetch the list of running containers to check against it in order to
 	// ensure we don't exceed the configured MaxConcurrentJobs limit.
-	containers, err := s.client.ContainerList(ctx, types.ContainerListOptions{})
+	containers, err := s.client.ContainerList(ctx, types.ContainerListOptions{
+		Filters: filters.NewArgs(filters.KeyValuePair{
+			Key:   "label",
+			Value: "app=mattermost-calls-offloader",
+		}),
+	})
 	if err != nil {
 		return job.Job{}, fmt.Errorf("failed to list containers: %w", err)
 	}
@@ -191,6 +285,10 @@ func (s *JobService) CreateJob(cfg job.Config, onStopCb job.StopCb) (job.Job, er
 		Tty:     false,
 		Env:     env,
 		Volumes: map[string]struct{}{volumeID + ":/recs": {}},
+		Labels: map[string]string{
+			// app label helps with identifying jobs.
+			"app": "mattermost-calls-offloader",
+		},
 	}, &container.HostConfig{
 		NetworkMode: networkMode,
 		Mounts: []mount.Mount{

--- a/service/jobs_service.go
+++ b/service/jobs_service.go
@@ -31,12 +31,12 @@ func NewJobService(cfg JobsConfig, log mlog.LoggerIFace) (JobService, error) {
 	case JobAPITypeDocker:
 		return docker.NewJobService(log, docker.JobServiceConfig{
 			MaxConcurrentJobs:       cfg.MaxConcurrentJobs,
-			FailedJobsRetentionTime: cfg.FailedJobsRetentionTime,
+			FailedJobsRetentionTime: cfg.FailedJobsRetentionTime.Duration(),
 		})
 	case JobAPITypeKubernetes:
 		return kubernetes.NewJobService(log, kubernetes.JobServiceConfig{
 			MaxConcurrentJobs:       cfg.MaxConcurrentJobs,
-			FailedJobsRetentionTime: cfg.FailedJobsRetentionTime,
+			FailedJobsRetentionTime: cfg.FailedJobsRetentionTime.Duration(),
 		})
 	default:
 		return nil, fmt.Errorf("%s API is not implemeneted", cfg.APIType)

--- a/service/jobs_service.go
+++ b/service/jobs_service.go
@@ -30,11 +30,13 @@ func NewJobService(cfg JobsConfig, log mlog.LoggerIFace) (JobService, error) {
 	switch cfg.APIType {
 	case JobAPITypeDocker:
 		return docker.NewJobService(log, docker.JobServiceConfig{
-			MaxConcurrentJobs: cfg.MaxConcurrentJobs,
+			MaxConcurrentJobs:       cfg.MaxConcurrentJobs,
+			FailedJobsRetentionTime: cfg.FailedJobsRetentionTime,
 		})
 	case JobAPITypeKubernetes:
 		return kubernetes.NewJobService(log, kubernetes.JobServiceConfig{
-			MaxConcurrentJobs: cfg.MaxConcurrentJobs,
+			MaxConcurrentJobs:       cfg.MaxConcurrentJobs,
+			FailedJobsRetentionTime: cfg.FailedJobsRetentionTime,
 		})
 	default:
 		return nil, fmt.Errorf("%s API is not implemeneted", cfg.APIType)

--- a/service/jobs_service.go
+++ b/service/jobs_service.go
@@ -31,12 +31,12 @@ func NewJobService(cfg JobsConfig, log mlog.LoggerIFace) (JobService, error) {
 	case JobAPITypeDocker:
 		return docker.NewJobService(log, docker.JobServiceConfig{
 			MaxConcurrentJobs:       cfg.MaxConcurrentJobs,
-			FailedJobsRetentionTime: cfg.FailedJobsRetentionTime.Duration(),
+			FailedJobsRetentionTime: cfg.FailedJobsRetentionTime,
 		})
 	case JobAPITypeKubernetes:
 		return kubernetes.NewJobService(log, kubernetes.JobServiceConfig{
 			MaxConcurrentJobs:       cfg.MaxConcurrentJobs,
-			FailedJobsRetentionTime: cfg.FailedJobsRetentionTime.Duration(),
+			FailedJobsRetentionTime: cfg.FailedJobsRetentionTime,
 		})
 	default:
 		return nil, fmt.Errorf("%s API is not implemeneted", cfg.APIType)


### PR DESCRIPTION
#### Summary

PR implements a retention policy for failed jobs through the use of a new `failed_jobs_retention_time` config setting. So far we only deleted successful jobs to prevent data loss. However this has caused a bit of a pain in production as we had many failures which always required manual intervention.

Implementation wise this is trivial to do in the `kubernetes` case as there's a setting that does it automatically (`TTLSecondsAfterFinished`). For `docker` we implement a simple cronjob.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49202
