### PR TITLE
[MM-55475] Performance tests

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -30,6 +30,42 @@ On the Mattermost side, it may also be necessary to tune the [`FileSettings.MaxF
 > If a load-balancer or proxy is in front of Mattermost, extra configuration may be necessary. 
 > As an example, `nginx` would likely require `client_max_body_size` to be set accordingly.
 
+### Calls Transcriptions
+
+#### Deployment
+
+- `calls-offloader` `v0.5.0`
+- `calls-transcriber` `v0.1.0`
+- `c6i.2xlarge` EC2 instance
+	- 8vCPU / 16GB RAM
+
+#### Model sizes
+
+The transcriber's model size can be configured through the [Calls plugin](https://docs.mattermost.com/configure/plugins-configuration-settings.html#transcriber-model-size). At this time we support the following [Whisper.cpp](https://huggingface.co/ggerganov/whisper.cpp) models:
+
+| Model | File size | Memory |
+|------:|----------:|-------:|
+| tiny  | 75MB      |~273MB  |
+| base  | 142MB     |~388MB  |
+| small | 466MB     |~852MB  |
+
+#### Benchmarks
+
+| Model | Threads | CPU (avg) | Memory (avg) | Call duration | Processing time |
+|-------|---------|-----------|--------------|---------------|-----------------|
+| tiny  | 1       | 13.5%     | 1.20GB       | 10m           | 2m20s (4.28x)   |
+| base  | 1       | 13.0%     | 1.23GB       | 10m           | 4m45s (2.10x)   |
+| small | 1       | 12.8%     | 1.67GB       | 10m           | 16m50s (0.59x)  |
+| tiny  | 2       | 25.0%     | 1.20GB       | 10m           | 1m17s (7.79x)   |
+| base  | 2       | 25.5%     | 1.27GB       | 10m           | 2m41s (3.73x)   |
+| small | 2       | 25.3%     | 1.68GB       | 10m           | 9m23s (1.07x)   |
+| tiny  | 4       | 49.4%     | 1.20GB       | 10m           | 45s (13.33x)    |
+| base  | 4       | 49.8%     | 1.27GB       | 10m           | 1m32s (6.52x)   |
+| small | 4       | 49.6%     | 1.71GB       | 10m           | 5m27s (1.84x)   |
+| tiny  | 4       | 48.7%     | 1.85GB       | 60m           | 3m38s (16.51x)  |
+| base  | 4       | 49.5%     | 1.70GB       | 60m           | 7m6s (8.45x)    |
+| small | 4       | 50.0%     | 1.99GB       | 60m           | 22m50s (2.63x)  |
+
 ## Scalability
 
 Starting in version `v0.3.2`, this service includes support for horizontal scalability. This can be achieved by adding an HTTP load balancer in front of multiple `calls-offloader` instances, and configuring the [Job Service URL](https://docs.mattermost.com/configure/plugins-configuration-settings.html#job-service-url) setting accordingly to point to the balancer's host.


### PR DESCRIPTION
#### Summary

Attaching the results of preliminary performance tests. I selected the same instance type we use in production for recordings `c6i.2xlarge` and executed on all the models we include (`tiny`, `base`, `small`) with a base sample of 10 minutes.

For the default configuration of threads (NumCPU / 2) I also performed tests on a full hour of meeting sample.

The call samples were extracted from real developers meetings so the test should be as close as possible to a real use case with the caveat that it was a single track. In general though I wouldn't expect multiple tracks to cause significant overhead since it's unlikely for speech from different tracks to be overlapping for long periods.

What's likely causing some overhead is the number of speech segments that we get out of these tracks (due to the speech detection process). We can probably tune this further to try and minimize the number of contiguous samples. Right now we are using a value of 2 seconds of silence after which we split.

Overall the results show almost linear performance gains with the number of threads of execution.

Please let me know if you have any questions or concerns.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-55475
