### PR TITLE
[MM-56184] Allow passing Kubernetes resource requirements to jobs

### DIFF
--- a/config/config.sample.toml
+++ b/config/config.sample.toml
@@ -37,6 +37,11 @@ max_concurrent_jobs = 2
 # The supported units of time are "m" (minutes), "h" (hours) and "d" (days).
 failed_jobs_retention_time = "30d"
 
+# Kubernetes API optionally supports definining resource limits and requests on
+# a per job type basis. Example:
+#[jobs.kubernetes]
+#jobs_resource_requirements = '{"transcribing": {"limits": {"cpu": "2000m"}}, "recording": {"limits": {"cpu": "500"}}}'
+
 [logger]
 # A boolean controlling whether to log to the console.
 enable_console = true

--- a/config/config.sample.toml
+++ b/config/config.sample.toml
@@ -40,7 +40,7 @@ failed_jobs_retention_time = "30d"
 # Kubernetes API optionally supports definining resource limits and requests on
 # a per job type basis. Example:
 #[jobs.kubernetes]
-#jobs_resource_requirements = '{"transcribing": {"limits": {"cpu": "2000m"}}, "recording": {"limits": {"cpu": "500"}}}'
+#jobs_resource_requirements = '{"transcribing":{"limits":{"cpu":"4000m"},"requests":{"cpu":"2000m"}},"recording":{"limits":{"cpu":"2000m"},"requests":{"cpu":"1000m"}}}'
 
 [logger]
 # A boolean controlling whether to log to the console.

--- a/public/job/job.go
+++ b/public/job/job.go
@@ -22,6 +22,8 @@ const (
 const (
 	MinSupportedRecorderVersion    = "0.6.0"
 	MinSupportedTranscriberVersion = "0.1.0"
+	RecordingJobPrefix             = "calls-recorder"
+	TranscribingJobPrefix          = "calls-transcriber"
 )
 
 var (

--- a/service/config_test.go
+++ b/service/config_test.go
@@ -84,7 +84,7 @@ func TestParseFromEnv(t *testing.T) {
 		var cfg Config
 		err := cfg.ParseFromEnv()
 		require.NoError(t, err)
-		require.Equal(t, time.Hour*24, cfg.Jobs.FailedJobsRetentionTime)
+		require.Equal(t, RetentionTime(time.Hour*24), cfg.Jobs.FailedJobsRetentionTime)
 	})
 
 	t.Run("override", func(t *testing.T) {

--- a/service/docker/service.go
+++ b/service/docker/service.go
@@ -34,11 +34,6 @@ const (
 	dockerVolumePath       = "/data"
 )
 
-const (
-	recordingJobPrefix    = "calls-recorder"
-	transcribingJobPrefix = "calls-transcriber"
-)
-
 var (
 	dockerStopTimeout          = 5 * time.Minute
 	dockerRetentionJobInterval = time.Minute
@@ -292,13 +287,13 @@ func (s *JobService) CreateJob(cfg job.Config, onStopCb job.StopCb) (job.Job, er
 		var jobData recorder.RecorderConfig
 		jobData.FromMap(cfg.InputData)
 		jobData.SiteURL = getSiteURLForJob(jobData.SiteURL)
-		jobPrefix = recordingJobPrefix
+		jobPrefix = job.RecordingJobPrefix
 		env = append(env, jobData.ToEnv()...)
 	case job.TypeTranscribing:
 		var jobData transcriber.CallTranscriberConfig
 		jobData.FromMap(cfg.InputData)
 		jobData.SiteURL = getSiteURLForJob(jobData.SiteURL)
-		jobPrefix = transcribingJobPrefix
+		jobPrefix = job.TranscribingJobPrefix
 		env = append(env, jobData.ToEnv()...)
 	}
 

--- a/service/docker/service.go
+++ b/service/docker/service.go
@@ -49,6 +49,18 @@ type JobServiceConfig struct {
 	FailedJobsRetentionTime time.Duration
 }
 
+func (c JobServiceConfig) IsValid() error {
+	if c.MaxConcurrentJobs < 0 {
+		return fmt.Errorf("invalid MaxConcurrentJobs value: should be positive")
+	}
+
+	if c.FailedJobsRetentionTime > 0 && c.FailedJobsRetentionTime < time.Minute {
+		return fmt.Errorf("invalid FailedJobsRetentionTime value: should be at least one minute")
+	}
+
+	return nil
+}
+
 type JobService struct {
 	cfg JobServiceConfig
 	log mlog.LoggerIFace
@@ -261,7 +273,7 @@ func (s *JobService) CreateJob(cfg job.Config, onStopCb job.StopCb) (job.Job, er
 	if err != nil {
 		return job.Job{}, fmt.Errorf("failed to list containers: %w", err)
 	}
-	if len(containers) >= s.cfg.MaxConcurrentJobs {
+	if s.cfg.MaxConcurrentJobs > 0 && len(containers) >= s.cfg.MaxConcurrentJobs {
 		if !devMode {
 			return job.Job{}, fmt.Errorf("max concurrent jobs reached")
 		}

--- a/service/helper_test.go
+++ b/service/helper_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mattermost/calls-offloader/public"
 	"github.com/mattermost/calls-offloader/service/api"
 	"github.com/mattermost/calls-offloader/service/auth"
+	"github.com/mattermost/calls-offloader/service/docker"
 
 	"github.com/stretchr/testify/require"
 )
@@ -86,6 +87,9 @@ func MakeDefaultCfg(tb testing.TB) *Config {
 		Jobs: JobsConfig{
 			APIType:           JobAPITypeDocker,
 			MaxConcurrentJobs: 2,
+			Docker: docker.JobServiceConfig{
+				MaxConcurrentJobs: 2,
+			},
 		},
 		Logger: logger.Config{
 			EnableConsole: true,

--- a/service/kubernetes/service.go
+++ b/service/kubernetes/service.go
@@ -36,15 +36,10 @@ const (
 	k8sVolumePath         = "/data"
 )
 
-const (
-	recordingJobPrefix    = "calls-recorder"
-	transcribingJobPrefix = "calls-transcriber"
-)
+// Type alias and custom decoders to support passing JSON from both TOML config and env
+// variable.
 
 type JobsResourceRequirements map[job.Type]corev1.ResourceRequirements
-
-// Custom decoders to support passing JSON from both TOML config and env
-// variable.
 
 func (r *JobsResourceRequirements) Decode(data string) error {
 	return yaml.NewYAMLOrJSONDecoder(bytes.NewBuffer([]byte(data)), 0).Decode(r)
@@ -166,7 +161,7 @@ func (s *JobService) CreateJob(cfg job.Config, onStopCb job.StopCb) (job.Job, er
 		jobCfg.FromMap(cfg.InputData)
 		jobCfg.SetDefaults()
 		jobCfg.SiteURL = getSiteURLForJob(jobCfg.SiteURL)
-		jobPrefix = recordingJobPrefix
+		jobPrefix = job.RecordingJobPrefix
 		jobID = jobPrefix + "-job-" + random.NewID()
 		env = append(env, getEnvFromJobConfig(jobCfg)...)
 		initContainers = []corev1.Container{
@@ -191,7 +186,7 @@ func (s *JobService) CreateJob(cfg job.Config, onStopCb job.StopCb) (job.Job, er
 		jobCfg.FromMap(cfg.InputData)
 		jobCfg.SetDefaults()
 		jobCfg.SiteURL = getSiteURLForJob(jobCfg.SiteURL)
-		jobPrefix = transcribingJobPrefix
+		jobPrefix = job.TranscribingJobPrefix
 		jobID = jobPrefix + "-job-" + random.NewID()
 		env = append(env, getEnvFromJobConfig(jobCfg)...)
 	}


### PR DESCRIPTION
#### Summary

We want to allow setting resource limits and requests for jobs we manage so that it's easier for Kubernetes to schedule them properly based on available nodes resources.

I kept the implementation simple to avoid redefining a bunch of K8S types. The downside is that we need to pass some potentially ugly JSON but the alternative seemed just a lot of repetition and potentially less powerful overall. 

This is how it would look like to define specific limits and requests for both jobs we support today from a helm chart:

```
- name: JOBS_KUBERNETES_JOBSRESOURCEREQUIREMENTS
  value: "{\"transcribing\":{\"limits\":{\"cpu\":\"4000m\"},\"requests\":{\"cpu\":\"2000m\"}},\"recording\":{\"limits\":{\"cpu\":\"2000m\"},\"requests\":{\"cpu\":\"1000m\"}}}"
```

Again, thanks @gabrieljackson for the tip :)

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-56184
