### PR TITLE
Return error in case of failure to start HTTP server

### DIFF
--- a/service/api/server_test.go
+++ b/service/api/server_test.go
@@ -67,6 +67,23 @@ func TestStartServer(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	t.Run("invalid certificate", func(t *testing.T) {
+		cfg := Config{
+			ListenAddress: ":0",
+			TLS: TLSConfig{
+				Enable:   true,
+				CertFile: "../../testfiles/invalid_tls_test_cert.pem",
+				CertKey:  "../../testfiles/tls_test_key.pem",
+			},
+		}
+		s, err := NewServer(cfg, log)
+		require.NoError(t, err)
+		require.NotNil(t, s)
+
+		err = s.Start()
+		require.EqualError(t, err, "open ../../testfiles/invalid_tls_test_cert.pem: no such file or directory")
+	})
+
 	t.Run("tls", func(t *testing.T) {
 		cfg := Config{
 			ListenAddress: ":0",


### PR DESCRIPTION
#### Summary

A small usability improvement. We return an error in case the HTTP server fails to start immediately (up to a second). This can happen, for example, due to an invalid certificate provided (added a test for this case).
