### PR TITLE
[MM-57483] Decouple service from job specific configs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,6 @@ require (
 	github.com/docker/docker v20.10.9+incompatible
 	github.com/gorilla/mux v1.8.1
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/mattermost/calls-recorder v0.6.0
-	github.com/mattermost/calls-transcriber v0.1.9-0.20240207195159-3f96d0ad8031
 	github.com/mattermost/mattermost/server/public v0.0.12
 	github.com/pborman/uuid v1.2.1
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -535,10 +535,6 @@ github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
-github.com/mattermost/calls-recorder v0.6.0 h1:ZDaaUseWoUyAZXwBEIFPhkhHbzD+GpBSYedUmAPN+JI=
-github.com/mattermost/calls-recorder v0.6.0/go.mod h1:v/52mE+wIXGJE7ZflpAkoyGd56hbVgC9ZuEBBaRd8KU=
-github.com/mattermost/calls-transcriber v0.1.9-0.20240207195159-3f96d0ad8031 h1:i1+vxipBtHo0zQT+ABen5WiC6q3KD3cPSJ/RkvwF3L4=
-github.com/mattermost/calls-transcriber v0.1.9-0.20240207195159-3f96d0ad8031/go.mod h1:FHCpAazodwWFT8da1Z3Sg/TOJu5M0h5ShWomMAamVmA=
 github.com/mattermost/logr/v2 v2.0.21 h1:CMHsP+nrbRlEC4g7BwOk1GAnMtHkniFhlSQPXy52be4=
 github.com/mattermost/logr/v2 v2.0.21/go.mod h1:kZkB/zqKL9e+RY5gB3vGpsyenC+TpuiOenjMkvJJbzc=
 github.com/mattermost/mattermost/server/public v0.0.12 h1:iunc9q4/XkArOrndEUn73uFw6v9TOEXEtp6Nm6Iv218=

--- a/service/docker/service_test.go
+++ b/service/docker/service_test.go
@@ -14,8 +14,6 @@ import (
 
 	"github.com/mattermost/calls-offloader/public/job"
 
-	recorder "github.com/mattermost/calls-recorder/cmd/recorder/config"
-
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
 
 	"github.com/stretchr/testify/require"
@@ -75,20 +73,18 @@ func TestCreateJob(t *testing.T) {
 	os.Setenv("TEST_MODE", "true")
 	defer os.Unsetenv("TEST_MODE")
 
-	var recCfg recorder.RecorderConfig
-	recCfg.SetDefaults()
-	recCfg.SiteURL = "http://localhost:8065"
-	recCfg.CallID = "8w8jorhr7j83uqr6y1st894hqe"
-	recCfg.PostID = "udzdsg7dwidbzcidx5khrf8nee"
-	recCfg.AuthToken = "qj75unbsef83ik9p7ueypb6iyw"
-	recCfg.RecordingID = "dtomsek53i8eukrhnb31ugyhea"
-
 	stopCh := make(chan struct{})
 	job, err := jobService.CreateJob(job.Config{
 		Type:           job.TypeRecording,
 		Runner:         testRunner,
 		MaxDurationSec: 60,
-		InputData:      recCfg.ToMap(),
+		InputData: job.InputData{
+			"site_url":     "http://localhost:8065",
+			"call_id":      "8w8jorhr7j83uqr6y1st894hqe",
+			"post_id":      "udzdsg7dwidbzcidx5khrf8nee",
+			"auth_token":   "qj75unbsef83ik9p7ueypb6iyw",
+			"recording_id": "dtomsek53i8eukrhnb31ugyhea",
+		},
 	}, func(_ job.Job, success bool) error {
 		require.True(t, success)
 		close(stopCh)
@@ -122,14 +118,6 @@ func TestFailedJobsRetention(t *testing.T) {
 	os.Setenv("TEST_MODE", "true")
 	defer os.Unsetenv("TEST_MODE")
 
-	var recCfg recorder.RecorderConfig
-	recCfg.SetDefaults()
-	recCfg.SiteURL = "http://localhost:8065"
-	recCfg.CallID = "8w8jorhr7j83uqr6y1st894hqe"
-	recCfg.PostID = "udzdsg7dwidbzcidx5khrf8nee"
-	recCfg.AuthToken = "qj75unbsef83ik9p7ueypb6iyw"
-	recCfg.RecordingID = "dtomsek53i8eukrhnb31ugyhea"
-
 	interval := dockerRetentionJobInterval
 	dockerRetentionJobInterval = time.Second
 	defer func() {
@@ -148,7 +136,13 @@ func TestFailedJobsRetention(t *testing.T) {
 		Type:           job.TypeRecording,
 		Runner:         testRunner,
 		MaxDurationSec: 60,
-		InputData:      recCfg.ToMap(),
+		InputData: job.InputData{
+			"site_url":     "http://localhost:8065",
+			"call_id":      "8w8jorhr7j83uqr6y1st894hqe",
+			"post_id":      "udzdsg7dwidbzcidx5khrf8nee",
+			"auth_token":   "qj75unbsef83ik9p7ueypb6iyw",
+			"recording_id": "dtomsek53i8eukrhnb31ugyhea",
+		},
 	}, func(_ job.Job, success bool) error {
 		require.True(t, success)
 		close(stopCh)

--- a/service/kubernetes/utils.go
+++ b/service/kubernetes/utils.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/mattermost/calls-offloader/public/job"
+
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
@@ -42,13 +44,9 @@ func newBool(val bool) *bool {
 	return p
 }
 
-type Mapper interface {
-	ToMap() map[string]any
-}
-
-func getEnvFromJobConfig(cfg Mapper) []corev1.EnvVar {
+func getEnvFromJobInputData(data job.InputData) []corev1.EnvVar {
 	var env []corev1.EnvVar
-	for k, v := range cfg.ToMap() {
+	for k, v := range data {
 		env = append(env, corev1.EnvVar{
 			Name:  strings.ToUpper(k),
 			Value: fmt.Sprintf("%v", v),

--- a/service/kubernetes/utils_test.go
+++ b/service/kubernetes/utils_test.go
@@ -5,38 +5,40 @@ import (
 	"os"
 	"testing"
 
-	recorder "github.com/mattermost/calls-recorder/cmd/recorder/config"
+	"github.com/mattermost/calls-offloader/public/job"
 
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetEnvFromJobConfig(t *testing.T) {
+func TestGetEnvFromJobInputData(t *testing.T) {
 	tcs := []struct {
 		name string
-		cfg  recorder.RecorderConfig
+		data job.InputData
 		env  []corev1.EnvVar
 	}{
 		{
-			name: "empty config",
-			cfg:  recorder.RecorderConfig{},
+			name: "empty data",
+			data: job.InputData{},
 			env:  []corev1.EnvVar(nil),
 		},
 		{
-			name: "valid config",
-			cfg: func() recorder.RecorderConfig {
-				var cfg recorder.RecorderConfig
-				cfg.SetDefaults()
-
-				cfg.SiteURL = "http://localhost:8065"
-				cfg.AuthToken = "authToken"
-				cfg.CallID = "callID"
-				cfg.PostID = "postID"
-				cfg.RecordingID = "recordingID"
-
-				return cfg
-			}(),
+			name: "valid data",
+			data: job.InputData{
+				"site_url":      "http://localhost:8065",
+				"auth_token":    "authToken",
+				"call_id":       "callID",
+				"post_id":       "postID",
+				"recording_id":  "recordingID",
+				"width":         1920,
+				"height":        1080,
+				"video_rate":    1500,
+				"audio_rate":    64,
+				"frame_rate":    30,
+				"video_preset":  "fast",
+				"output_format": "mp4",
+			},
 			env: []corev1.EnvVar{
 				{
 					Name:  "SITE_URL",
@@ -92,7 +94,7 @@ func TestGetEnvFromJobConfig(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			env := getEnvFromJobConfig(tc.cfg)
+			env := getEnvFromJobInputData(tc.data)
 			require.ElementsMatch(t, tc.env, env)
 		})
 	}


### PR DESCRIPTION
#### Summary

PR decouples this service from any job specific config. This assumes proper validation should be performed preferably on the client side (plugin).

#### Related PR

https://github.com/mattermost/mattermost-plugin-calls/pull/667

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-57483
