### PR TITLE
[MM-62189] Allow passing custom node level sysctls

### DIFF
--- a/config/config.sample.toml
+++ b/config/config.sample.toml
@@ -47,6 +47,11 @@ image_registry = "mattermost"
 #
 # The Persistent Volume Claim name to use to store data produced by jobs (e.g. recording files).
 #persistent_volume_claim_name = "my-pvc"
+#
+# A comma separated list of Sysctls to apply on the node through priviledged init container before starting jobs.
+# For example, enabling the `kernel.unprivileged_userns_clone` at node level was necessary
+# on Debian based systems (pre kernel 5.10) in order to run Chromium sandbox.
+#node_sysctls = "kernel.unprivileged_userns_clone=1"
 
 [logger]
 # A boolean controlling whether to log to the console.

--- a/service/kubernetes/utils.go
+++ b/service/kubernetes/utils.go
@@ -114,3 +114,37 @@ func getSiteURLForJob(siteURL string) string {
 
 	return siteURL
 }
+
+func genInitContainers(jobID, image, sysctls string) ([]corev1.Container, error) {
+	if jobID == "" {
+		return nil, fmt.Errorf("invalid empty jobID")
+	}
+
+	if image == "" {
+		return nil, fmt.Errorf("invalid empty image")
+	}
+
+	if sysctls == "" {
+		return nil, fmt.Errorf("invalid empty sysctls")
+	}
+
+	ctls := strings.Split(sysctls, ",")
+	cnts := make([]corev1.Container, len(ctls))
+	for i, ctl := range ctls {
+		cnts[i] = corev1.Container{
+			Name:            fmt.Sprintf("%s-init-%d", jobID, i),
+			Image:           image,
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Command: []string{
+				"sysctl",
+				"-w",
+				ctl,
+			},
+			SecurityContext: &corev1.SecurityContext{
+				Privileged: newBool(true),
+			},
+		}
+	}
+
+	return cnts, nil
+}


### PR DESCRIPTION
#### Summary

PR removes the init container setting the [deprecated](https://www.debian.org/releases/bullseye/amd64/release-notes/ch-information.en.html#linux-user-namespaces) `kernel.unprivileged_userns_clone=1` and adds a new `node_sysctls` config setting to let admins set custom sysctls that may be needed at the node level.

This new config is also controlled by the `JOBS_KUBERNETES_NODESYSCTLS` env var.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-62189
