### PR TITLE
[MM-63296] Bump Golang version to v1.23.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mattermost/calls-offloader
 
-go 1.22.7
+go 1.23.6
 
 require (
 	git.mills.io/prologic/bitcask v1.0.2


### PR DESCRIPTION
#### Summary

Bumping the Golang version used to build. 

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-63296
