### PR TITLE
[MM-64441] Add setting to control outputting job logs

### DIFF
--- a/config/config.sample.toml
+++ b/config/config.sample.toml
@@ -53,6 +53,11 @@ image_registry = "mattermost"
 # on Debian based systems (pre kernel 5.10) in order to run Chromium sandbox.
 #node_sysctls = "kernel.unprivileged_userns_clone=1"
 
+# Docker API specific settings
+# [jobs.docker]
+# Whether to output job logs to the console. Default is false.
+# output_logs = false
+
 [logger]
 # A boolean controlling whether to log to the console.
 enable_console = true


### PR DESCRIPTION
#### Summary

During initial deployment, checking logs from jobs can be helpful for debugging failures. However, since jobs that fail on startup are not retained, accessing their logs can be tricky since it requires careful timing with the `docker logs` command.

To simplify this, we introduce a new configuration setting that allows admins to direct job logs to the console.

/cc @sadohert 

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-64441
